### PR TITLE
pass nightmare dep into module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ This library will not be ready for use until [Nightmare #391](https://github.com
 Add window management to your [Nightmare](http://github.com/segmentio/nightmare) scripts.
 
 ## Usage
-Simply require the library: 
+Simply require the library:
 
 ```js
-require('nightmare-window-manager')
+var Nightmare = require('nightmare')
+require('nightmare-window-manager')(Nightmare)
 ```
 ... and then enable the window manager with `.windowManager()`.  It should be the first call in your Nightmare chain.
 
@@ -38,8 +39,8 @@ Invokes `fn` on the currently selected window with the arguments supplied.  All 
 ## Example
 ```js
 var Nightmare = require('nightmare');
-require('nightmare-window-manager');
-var nightmare = Nighmare();
+require('nightmare-window-manager')(Nightmare);
+var nightmare = Nightmare();
 nightmare
     .windowManager()
     .goto(url)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 nightmare-window-manager
 ======================
-
-# Important Note
-This library will not be ready for use until [Nightmare #391](https://github.com/segmentio/nightmare/issues/391) is completed.  For now, if this library is needed, use the [`electron-plugin` branch from my fork](https://github.com/rosshinkley/nightmare/tree/electron-plugin).
-
 Add window management to your [Nightmare](http://github.com/segmentio/nightmare) scripts.
 
 ## Usage

--- a/nightmare-window-manager.js
+++ b/nightmare-window-manager.js
@@ -1,212 +1,213 @@
-var Nightmare = require('nightmare'),
-  debug = require('debug')('nightmare:window-manager');
+var debug = require('debug')('nightmare:window-manager');
 
-Nightmare.action('windowManager', function(name, options, parent, win, renderer, done) {
-  parent.on('windowManager', function() {
-    var app = require('electron')
-      .app;
-    app.on('browser-window-created', function(event, win) {
-      win.webContents.on('did-finish-load', function(event) {
-        parent.emit('changeFocusWindow', win.id);
+module.exports = function(Nightmare) {
+  Nightmare.action('windowManager', function(name, options, parent, win, renderer, done) {
+    parent.on('windowManager', function() {
+      var app = require('electron')
+        .app;
+      app.on('browser-window-created', function(event, win) {
+        win.webContents.on('did-finish-load', function(event) {
+          parent.emit('changeFocusWindow', win.id);
+        });
       });
+      parent.emit('windowManager');
     });
-    parent.emit('windowManager');
+    done();
+  }, function(done) {
+    var self = this;
+    this.focusedWindow = 1;
+    this.child.on('changeFocusWindow', function(windowId) {
+      self.focusedWindow = windowId;
+    });
+    this.child.once('windowManager', done);
+    this.child.emit('windowManager');
   });
-  done();
-}, function(done) {
-  var self = this;
-  this.focusedWindow = 1;
-  this.child.on('changeFocusWindow', function(windowId) {
-    self.focusedWindow = windowId;
-  });
-  this.child.once('windowManager', done);
-  this.child.emit('windowManager');
-});
 
-Nightmare.action('windows',
-  function(name, options, parent, win, renderer, done) {
-    parent.on('windows', function(focusedWindowId) {
+  Nightmare.action('windows',
+    function(name, options, parent, win, renderer, done) {
+      parent.on('windows', function(focusedWindowId) {
+        var BrowserWindow = require('electron')
+          .BrowserWindow;
+        var windows = BrowserWindow.getAllWindows()
+          .map(function(win) {
+            return {
+              id: win.id,
+              isDestroyed: win.isDestroyed(),
+              isFocused: win.id == focusedWindowId,
+              isVisible: win.isVisible(),
+              bounds: win.getBounds(),
+              size: win.getSize(),
+              contentSize: win.getContentSize(),
+              isClosable: win.isClosable(),
+              title: win.getTitle(),
+              url: win.getURL(),
+            };
+          });
+
+        parent.emit('windows', windows);
+      });
+      done();
+      return this;
+    },
+    function(done) {
+      debug('windows');
+      this.child.once('windows', function(windows) {
+        done(null, windows);
+      });
+      this.child.emit('windows', this.focusedWindow);
+    });
+
+  Nightmare.action('waitWindowLoad',
+    function(name, options, parent, win, renderer, done) {
       var BrowserWindow = require('electron')
         .BrowserWindow;
-      var windows = BrowserWindow.getAllWindows()
-        .map(function(win) {
-          return {
-            id: win.id,
-            isDestroyed: win.isDestroyed(),
-            isFocused: win.id == focusedWindowId,
-            isVisible: win.isVisible(),
-            bounds: win.getBounds(),
-            size: win.getSize(),
-            contentSize: win.getContentSize(),
-            isClosable: win.isClosable(),
-            title: win.getTitle(),
-            url: win.getURL(),
-          };
+      parent.on('waitWindowLoad', function() {
+        var wait = function() {
+          setTimeout(function() {
+            var isLoading = BrowserWindow.getAllWindows()
+              .map(function(win) {
+                return win.webContents.isLoading();
+              })
+              .reduce(function(accumulator, value) {
+                return accumulator || value;
+              }, false);
+            if (isLoading) {
+              wait();
+            } else {
+              parent.emit('waitWindowLoad');
+            }
+
+          }, 250);
+        };
+        wait();
+      })
+      done();
+    },
+    function(done) {
+      debug('waitWindowLoad');
+      this.child.once('waitWindowLoad', done);
+      this.child.emit('waitWindowLoad');
+    });
+
+  Nightmare.action('currentWindow',
+    function(name, options, parent, win, renderer, done) {
+      var BrowserWindow = require('electron')
+        .BrowserWindow;
+      parent.on('currentWindow', function(focusedWindowId) {
+        var win = BrowserWindow.fromId(focusedWindowId);
+        current = {
+          id: win.id,
+          isDestroyed: win.isDestroyed(),
+          isFocused: win.isFocused(),
+          isVisible: win.isVisible(),
+          bounds: win.getBounds(),
+          size: win.getSize(),
+          contentSize: win.getContentSize(),
+          isClosable: win.isClosable(),
+          title: win.getTitle(),
+          url: win.getURL(),
+        };
+        parent.emit('currentWindow', current);
+      });
+      done();
+      return this;
+    },
+    function(done) {
+      this.child.once('currentWindow', function(window) {
+        done(null, window);
+      });
+      this.child.emit('currentWindow', this.focusedWindow);
+    });
+
+  Nightmare.action('closeWindow',
+    function(name, options, parent, win, renderer, done) {
+      var BrowserWindow = require('electron')
+        .BrowserWindow;
+      parent.on('closeWindow', function(windowId, focusedWindow) {
+
+        var win = BrowserWindow.fromId(windowId);
+        win.close();
+
+        if (windowId == focusedWindow) {
+          var unclosedWindows = BrowserWindow.getAllWindows()
+            .filter(function(win) {
+              return !win.isDestroyed();
+            });
+          if (unclosedWindows.length == 0) {
+            throw new Error('no windows to fall back to!');
+          } else {
+            parent.emit('changeFocusWindow', unclosedWindows[0].id);
+          }
+        }
+
+        parent.emit('closeWindow');
+      });
+      done();
+      return this;
+    },
+    function(windowId, done) {
+      this.child.once('closeWindow', done);
+      this.child.emit('closeWindow', windowId, this.focusedWindow);
+    });
+
+  Nightmare.action('focusWindow',
+    function(name, options, parent, win, renderer, done) {
+      parent.on('focusWindow', function(windowId) {
+        parent.emit('changeFocusWindow', windowId);
+        parent.emit('focusWindow');
+      });
+      done();
+      return this;
+    },
+    function(windowId, done) {
+      this.child.once('focusWindow', done);
+      this.child.emit('focusWindow', windowId);
+    });
+
+  Nightmare.action('evaluateWindow',
+    function(name, options, parent, win, renderer, done) {
+      var BrowserWindow = require('electron')
+        .BrowserWindow;
+      parent.on('evaluateWindow', function(focusedWindowId, src) {
+        renderer.once('window-response', function(event, response) {
+          parent.emit('evaluateWindow', null, response);
         });
 
-      parent.emit('windows', windows);
-    });
-    done();
-    return this;
-  },
-  function(done) {
-    debug('windows');
-    this.child.once('windows', function(windows) {
-      done(null, windows);
-    });
-    this.child.emit('windows', this.focusedWindow);
-  });
+        renderer.once('window-error', function(event, error) {
+          parent.emit('evaluateWindow', error);
+        });
 
-Nightmare.action('waitWindowLoad',
-  function(name, options, parent, win, renderer, done) {
-    var BrowserWindow = require('electron')
-      .BrowserWindow;
-    parent.on('waitWindowLoad', function() {
-      var wait = function() {
-        setTimeout(function() {
-          var isLoading = BrowserWindow.getAllWindows()
-            .map(function(win) {
-              return win.webContents.isLoading();
-            })
-            .reduce(function(accumulator, value) {
-              return accumulator || value;
-            }, false);
-          if (isLoading) {
-            wait();
-          } else {
-            parent.emit('waitWindowLoad');
+        BrowserWindow.fromId(focusedWindowId)
+          .webContents.executeJavaScript(src);
+      });
+
+      done();
+      return this;
+    },
+    function(fn) {
+      var args = require('sliced')(arguments);
+      var done = args[args.length - 1];
+      var fntext = String(fn);
+      var stringArgsList = JSON.stringify(args.slice(1, -1))
+        .slice(1, -1);
+
+      this.child.once('evaluateWindow', function(err, result) {
+        if (err) return done(err);
+        done(null, result);
+      });
+
+      var template = `
+        (function javascriptWindow(){
+          try{
+            var response = (${fntext})(${stringArgsList});
+            __nightmare.ipc.send('window-response', response);
           }
+          catch(e){
+            __nightmare.ipc.send('error', e.message);
+          }
+        })();
+      `;
 
-        }, 250);
-      };
-      wait();
-    })
-    done();
-  },
-  function(done) {
-    debug('waitWindowLoad');
-    this.child.once('waitWindowLoad', done);
-    this.child.emit('waitWindowLoad');
-  });
-
-Nightmare.action('currentWindow',
-  function(name, options, parent, win, renderer, done) {
-    var BrowserWindow = require('electron')
-      .BrowserWindow;
-    parent.on('currentWindow', function(focusedWindowId) {
-      var win = BrowserWindow.fromId(focusedWindowId);
-      current = {
-        id: win.id,
-        isDestroyed: win.isDestroyed(),
-        isFocused: win.isFocused(),
-        isVisible: win.isVisible(),
-        bounds: win.getBounds(),
-        size: win.getSize(),
-        contentSize: win.getContentSize(),
-        isClosable: win.isClosable(),
-        title: win.getTitle(),
-        url: win.getURL(),
-      };
-      parent.emit('currentWindow', current);
+      this.child.emit('evaluateWindow', this.focusedWindow, template);
     });
-    done();
-    return this;
-  },
-  function(done) {
-    this.child.once('currentWindow', function(window) {
-      done(null, window);
-    });
-    this.child.emit('currentWindow', this.focusedWindow);
-  });
-
-Nightmare.action('closeWindow',
-  function(name, options, parent, win, renderer, done) {
-    var BrowserWindow = require('electron')
-      .BrowserWindow;
-    parent.on('closeWindow', function(windowId, focusedWindow) {
-
-      var win = BrowserWindow.fromId(windowId);
-      win.close();
-
-      if (windowId == focusedWindow) {
-        var unclosedWindows = BrowserWindow.getAllWindows()
-          .filter(function(win) {
-            return !win.isDestroyed();
-          });
-        if (unclosedWindows.length == 0) {
-          throw new Error('no windows to fall back to!');
-        } else {
-          parent.emit('changeFocusWindow', unclosedWindows[0].id);
-        }
-      }
-
-      parent.emit('closeWindow');
-    });
-    done();
-    return this;
-  },
-  function(windowId, done) {
-    this.child.once('closeWindow', done);
-    this.child.emit('closeWindow', windowId, this.focusedWindow);
-  });
-
-Nightmare.action('focusWindow',
-  function(name, options, parent, win, renderer, done) {
-    parent.on('focusWindow', function(windowId) {
-      parent.emit('changeFocusWindow', windowId);
-      parent.emit('focusWindow');
-    });
-    done();
-    return this;
-  },
-  function(windowId, done) {
-    this.child.once('focusWindow', done);
-    this.child.emit('focusWindow', windowId);
-  });
-
-Nightmare.action('evaluateWindow',
-  function(name, options, parent, win, renderer, done) {
-    var BrowserWindow = require('electron')
-      .BrowserWindow;
-    parent.on('evaluateWindow', function(focusedWindowId, src) {
-      renderer.once('window-response', function(event, response) {
-        parent.emit('evaluateWindow', null, response);
-      });
-
-      renderer.once('window-error', function(event, error) {
-        parent.emit('evaluateWindow', error);
-      });
-
-      BrowserWindow.fromId(focusedWindowId)
-        .webContents.executeJavaScript(src);
-    });
-
-    done();
-    return this;
-  },
-  function(fn) {
-    var args = require('sliced')(arguments);
-    var done = args[args.length - 1];
-    var fntext = String(fn);
-    var stringArgsList = JSON.stringify(args.slice(1, -1))
-      .slice(1, -1);
-
-    this.child.once('evaluateWindow', function(err, result) {
-      if (err) return done(err);
-      done(null, result);
-    });
-
-    var template = `
-      (function javascriptWindow(){
-        try{
-          var response = (${fntext})(${stringArgsList});
-          __nightmare.ipc.send('window-response', response);
-        }
-        catch(e){
-          __nightmare.ipc.send('error', e.message);
-        }
-      })();
-    `;
-
-    this.child.emit('evaluateWindow', this.focusedWindow, template);
-  });
+};

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "filter",
     "content"
   ],
+  "peerDependency": {
+    "nightmare": ">= 2.3.0"
+  },
   "dependencies": {
     "debug": "^2.2.0",
-    "nightmare": "git://github.com/rosshinkley/nightmare#electron-plugin",
     "sliced": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Because of the way npm handles dependencies (at least in some situations), if you install `nightmare-window-manager` as-is, it will get it's own version of nightmare, leaving the module you are using in your test/nightmare script unmodified. This fixes that issue in 2 ways:
- Requires `nightmare` object to be passed in explicitly and not requiring it's own version of `nightmare`
- Makes `nightmare` a peerDependency so npm does not install a separate version of `nightmare` for the window manager
